### PR TITLE
Get rid of recursive longmess() by using a simple stack trace

### DIFF
--- a/lib/Devel/TrackSIG.pm
+++ b/lib/Devel/TrackSIG.pm
@@ -49,7 +49,15 @@ sub _report {
 
   my $sources = $obj->[1];
 
-  my $msg = Carp::longmess("${action}ing signal handler '$key' at");
+  my $msg = do {
+    my $i;
+    my @stack;
+    while ( my @caller = caller $i++ ) {
+      push @stack, sprintf '    %s::%s called at %s line %s', @caller[0,3,1,2];
+    }
+    "${action}ing signal handler '$key' at" . join("\n", @stack );
+  };
+
   if ($opt{track_source}) {
     $sources->{$key} = $msg;
   }


### PR DESCRIPTION
Carp includes signal handling after version 1.24:
    https://metacpan.org/diff/file?target=ZEFRAM/Carp-1.24/lib/Carp.pm&source=ZEFRAM/Carp-1.23/lib/Carp.pm

which in turn makes the longmess usage recursive until perl version v5.20
which seems to have some sort of internal improvement for signal handling.

Use a poor mans stack trace instead of using Carp to avoid any problems.
